### PR TITLE
Tamanna

### DIFF
--- a/TagDB/public/css/style.css
+++ b/TagDB/public/css/style.css
@@ -101,9 +101,6 @@
     border: 1px solid #d4d4d4; /* Subtle border for container */
     padding: 10px;
 }
-#recentTagsDropdown{
-  font-family: Arial, sans-serif;
-}
 
 
 /* Dropdown content (hidden by default) */
@@ -346,4 +343,41 @@ header {
   border-bottom: 1px solid #ddd; /* Optional: Add a border for visual separation */
   padding: 15px; /* Maintain padding for better spacing */
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1); /* Subtle shadow for depth */
+}
+/* .popup {
+  position: absolute;
+  top: 60px;
+  right: 0;
+  z-index: 1000;
+  width: 200px;
+  display: none;
+}
+
+.d-none {
+  display: none !important;
+} */
+
+/* Style the dropdown item container */
+.dropdown-item-wrapper {
+  display: flex;
+  justify-content: space-between; /* Push the star to the right */
+  align-items: center; /* Vertically center both the text and the star */
+  padding: 5px 0; /* Optional: Add space around the text */
+}
+
+/* Style for the star icon */
+.favorite-btn {
+  font-size: 18px; /* Adjust the size of the star */
+  cursor: pointer;
+  color: #ffcc00; /* Yellow color for the star */
+}
+
+/* Optionally, change the color when the star is filled */
+.favorite-btn.bi-star-fill {
+  color: #ffcc00; /* Filled star color */
+}
+
+/* Optional: change the color of the star when hovered */
+.favorite-btn:hover {
+  color: #ffd700; /* Brighter yellow on hover */
 }

--- a/TagDB/public/js/tagExplorerScript.js
+++ b/TagDB/public/js/tagExplorerScript.js
@@ -549,3 +549,171 @@ function renderRecentTags() {
 
   console.log("Dropdown updated with recent tags.");
 }
+function clearRecentTags() {
+  localStorage.removeItem("recentSelections");
+  alert("cleared ")
+  renderRecentTags();
+  console.log("Recent tags cleared.");
+}
+// // Toggle popup visibility
+// function togglePopup() {
+//     const popup = document.getElementById("popup");
+//     popup.classList.toggle("d-none");
+//     clearRecentTags()
+// }
+
+const FAVORITE_TAGS_KEY = "favoriteTags";  // Key to store favorite tags in localStorage
+const MAX_FAVORITE_TAGS = 5;  // Maximum number of favorite tags to store
+
+// Function to store a tag in local storage
+function storeFavoriteTagInLocalStorage(tagType, id, parentTag, tagText, tagId) {
+  // Retrieve the existing favorite selections or initialize an empty array
+  let favoriteSelections = JSON.parse(localStorage.getItem(FAVORITE_TAGS_KEY)) || [];
+
+  // Create the tag object
+  const tagObject = {
+    tagType: tagType,
+    id: id,
+    parentTag: parentTag,
+    tagText: tagText,
+    tagId: tagId
+  };
+
+  console.log("Tag Type: " + tagType + ", ID: " + id + ", Tag Name: " + parentTag + ", Selected Value: " + tagText + ", Tag ID from clicked element:" + tagId);
+
+  // Avoid storing duplicates
+  const isDuplicate = favoriteSelections.some(
+    selection => selection.id === id && selection.tagType === tagType
+  );
+  if (isDuplicate) {
+    console.log("Duplicate tag detected; skipping storage.");
+    return;
+  }
+
+  // If the number of favorites exceeds the maximum limit, remove the oldest
+  if (favoriteSelections.length >= MAX_FAVORITE_TAGS) {
+    favoriteSelections.shift();  // Remove the oldest tag to make space
+  }
+
+  // Add the new tag object to the favorite selections
+  favoriteSelections.push(tagObject);
+
+  // Store the updated array back into localStorage
+  localStorage.setItem(FAVORITE_TAGS_KEY, JSON.stringify(favoriteSelections));
+
+  console.log("Tag added to favorite selections:", tagObject);
+
+  // Update the favorite tags dropdown
+  renderFavoriteTags();
+}
+
+// Function to render favorite tags in the dropdown
+function renderFavoriteTags() {
+  const dropdown = document.getElementById("favoriteTagsDropdown");
+  if (!dropdown) return;
+
+  // Clear existing content
+  dropdown.innerHTML = "";
+
+  // Retrieve the favorite selections from localStorage
+  const favoriteSelections = JSON.parse(localStorage.getItem(FAVORITE_TAGS_KEY)) || [];
+
+  // Add each tag as a link (`<a>` element) in the dropdown
+  favoriteSelections.forEach(tag => {
+    const link = document.createElement("a");
+    link.className = "draggable";
+    link.href = "#subitem1";
+    link.draggable = true;
+    link.dataset.tagName = tag.parentTag;
+    link.dataset.tagValue = tag.tagText;
+    link.dataset.tagId = tag.tagId;
+    link.dataset.subtagId = tag.id;
+    link.onclick = () =>
+      addTagOnClick(tag.tagType, tag.id, tag.parentTag, tag.tagText);
+
+    link.textContent = tag.tagText;
+    dropdown.appendChild(link);
+  });
+
+  console.log("Dropdown updated with favorite tags.");
+}
+
+// Function to add a tag to the favorite list (triggered by clicking the star icon)
+// Function to add a tag to the favorite list (triggered by clicking the star icon)
+// Function to add a tag to the favorite list (triggered by clicking the star icon)
+function addTagToFavorite(tagType, id, parentTag, tagText) {
+  // Store the tag in localStorage
+  storeFavoriteTagInLocalStorage(tagType, id, parentTag, tagText, id);
+
+  // Get the star element by its ID
+  const starElement = document.getElementById(`star-${id}`);
+  
+  if (starElement) {
+    // Change the star to a filled state
+    if (starElement.classList.contains("bi-star")) {
+      starElement.classList.remove("bi-star");
+      starElement.classList.add("bi-star-fill");
+    } else {
+      // Toggle back to empty state if already filled (optional behavior)
+      starElement.classList.remove("bi-star-fill");
+      starElement.classList.add("bi-star");
+    }
+  }
+}
+// Function to remove a tag from the favorite list (triggered by clicking the filled star icon)
+function removeTagFromFavorite(tagId) {
+  let favoriteSelections = JSON.parse(localStorage.getItem(FAVORITE_TAGS_KEY)) || [];
+  
+  // Remove the tag with the given tagId
+  favoriteSelections = favoriteSelections.filter(tag => tag.tagId !== tagId);
+
+  // Save the updated list back to localStorage
+  localStorage.setItem(FAVORITE_TAGS_KEY, JSON.stringify(favoriteSelections));
+
+  // Update the UI
+  const starElement = document.getElementById(`star-${tagId}`);
+  starElement.classList.remove("bi-star-fill");
+  
+  // Re-render the favorite tags dropdown
+  renderFavoriteTags();
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  const favoriteSelections = JSON.parse(localStorage.getItem(FAVORITE_TAGS_KEY)) || [];
+  favoriteSelections.forEach(fav => {
+    const starElement = document.getElementById(`star-${fav.id}`);
+    if (starElement) {
+      starElement.classList.add("bi-star-fill");
+      starElement.classList.remove("bi-star");
+    }
+  });
+});
+
+// function clearFavoriteTags() {
+//   localStorage.removeItem("favoriteTags");
+//   alert("cleared favorite ")
+//   renderFavoriteTags();
+//   console.log("Recent tags cleared.");
+// }
+
+
+function toggleFavoriteTag(tagType, id, parentTag, tagText) {
+  const starElement = document.getElementById(`star-${id}`);
+  const isFilled = starElement.classList.contains("bi-star-fill");
+
+  if (isFilled) {
+    // If the star is filled, remove the tag from favorites
+    removeTagFromFavorite(id);
+    starElement.classList.remove("bi-star-fill");
+    starElement.classList.add("bi-star");
+  } else {
+    // If the star is empty, add the tag to favorites
+    storeFavoriteTagInLocalStorage(tagType, id, parentTag, tagText, id);
+    starElement.classList.add("bi-star-fill");
+    starElement.classList.remove("bi-star");
+  }
+
+  // Update the favorite tags dropdown
+  renderFavoriteTags();
+}
+

--- a/TagDB/public/js/tagExplorerScript.js
+++ b/TagDB/public/js/tagExplorerScript.js
@@ -551,7 +551,7 @@ function renderRecentTags() {
 }
 function clearRecentTags() {
   localStorage.removeItem("recentSelections");
-  alert("cleared ")
+  alert("Click OK to delete all your recent favorite tags. ")
   renderRecentTags();
   console.log("Recent tags cleared.");
 }

--- a/TagDB/public/js/tagExplorerScript.js
+++ b/TagDB/public/js/tagExplorerScript.js
@@ -470,7 +470,7 @@ searchInput.addEventListener('input', function () {
 // browser local storage  part
 
 const RECENT_TAGS_KEY = "recentSelections";  // Key to store recent tags in local storage
-const MAX_RECENT_TAGS = 5;  // Maximum number of recent tags to store
+const MAX_RECENT_TAGS = 10;  // Maximum number of recent tags to store
 
 // Function to store a tag in local storage
 
@@ -542,7 +542,7 @@ function clearRecentTags() {
 // }
 
 const FAVORITE_TAGS_KEY = "favoriteTags";  // Key to store favorite tags in localStorage
-const MAX_FAVORITE_TAGS = 5;  // Maximum number of favorite tags to store
+const MAX_FAVORITE_TAGS = 10;  // Maximum number of favorite tags to store
 
 // Function to store a tag in local storage
 function storeFavoriteTagInLocalStorage(tagType, id, parentTag, tagText, tagId) {

--- a/TagDB/public/js/tagExplorerScript.js
+++ b/TagDB/public/js/tagExplorerScript.js
@@ -469,38 +469,13 @@ searchInput.addEventListener('input', function () {
 
 // browser local storage  part
 
-const RECENT_TAGS_KEY = "recentTags";  // Key to store recent tags in local storage
+const RECENT_TAGS_KEY = "recentSelections";  // Key to store recent tags in local storage
 const MAX_RECENT_TAGS = 5;  // Maximum number of recent tags to store
 
 // Function to store a tag in local storage
-function storeTagInLocalStorage(tagType, id, parentTag, tagText, tagId) {
-  // Retrieve the existing recent selections or initialize an empty array
-  let recentSelections = JSON.parse(localStorage.getItem('recentSelections')) || [];
-
-  // Create the tag object
-  const tagObject = {
-    tagType: tagType,
-    id: id,
-    parentTag: parentTag,
-    tagText: tagText,
-    tagId: tagId
-  };
-  console.log("Tag Type: " + tagType + ", ID: " + id + ", Tag Name: " + parentTag + ", Selected Value: " + tagText + ", Tag ID from clicked element:"  + tagId);
-
-  // Add the new tag object to the recent selections
-  recentSelections.push(tagObject);
-
-  // Store the updated array back into localStorage
-  localStorage.setItem('recentSelections', JSON.stringify(recentSelections));
-
-  console.log("Tag added to recent selections:", tagObject);
-  storeTagInLocalStorage(tagType, tagId, parentTag, tagName);
-
-
-}
 
 function storeTagInLocalStorage(tagType, id, parentTag, tagText) {
-  let recentSelections = JSON.parse(localStorage.getItem("recentSelections")) || [];
+  let recentSelections = JSON.parse(localStorage.getItem(RECENT_TAGS_KEY)) || [];
 
   const tagObject = { tagType, id, parentTag, tagText };
 
@@ -512,9 +487,13 @@ function storeTagInLocalStorage(tagType, id, parentTag, tagText) {
     console.log("Duplicate tag detected; skipping storage.");
     return;
   }
+  // If the number of favorites exceeds the maximum limit, remove the oldest
+  if (recentSelections.length >= MAX_RECENT_TAGS) {
+    recentSelections.shift();  // Remove the oldest tag to make space
+  }
 
   recentSelections.push(tagObject);
-  localStorage.setItem("recentSelections", JSON.stringify(recentSelections));
+  localStorage.setItem(RECENT_TAGS_KEY, JSON.stringify(recentSelections));
   console.log("Tag added:", tagObject);
 
   // Update the dropdown
@@ -716,4 +695,9 @@ function toggleFavoriteTag(tagType, id, parentTag, tagText) {
   // Update the favorite tags dropdown
   renderFavoriteTags();
 }
+
+document.addEventListener("DOMContentLoaded", function() {
+  renderRecentTags();  // Render recent tags from localStorage on page load
+  renderFavoriteTags();  // Render favorite tags from localStorage on page load
+});
 

--- a/TagDB/views/partials/head.ejs
+++ b/TagDB/views/partials/head.ejs
@@ -4,3 +4,5 @@
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet">
 <link rel="stylesheet" type="text/css" href="/css/style.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
+<link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.10.5/font/bootstrap-icons.css" rel="stylesheet">

--- a/TagDB/views/tag-explorer.ejs
+++ b/TagDB/views/tag-explorer.ejs
@@ -25,36 +25,31 @@
           <!-- Search -->
           <form class="d-flex mb-3" role="search">
             <input class="form-control me-2" type="search" id="searchInput" placeholder="Search" aria-label="Search" oninput="filterTags()">
-            <!-- <button class="btn btn-outline-success" type="submit">Search</button> -->
+            <button 
+            type="button" 
+            class="btn btn-outline-danger d-flex align-items-center justify-content-center rounded-circle" 
+            id="clearRecentsIcon" 
+            onclick="clearRecentTags()"
+            style="width: 40px; height: 40px;" 
+            aria-label="More options">
+            <i class="bi bi-three-dots"></i>
+          </button>
           </form>
+          
 
       
-          <button class="dropdown-btn">
-            <span>Favorites</span>
-            <span>&#9662;</span> <!-- Down arrow symbol -->
-          </button>
-          <div class = "dropdown-content">
-            <% tags.forEach(tag => { %>
-              <button class="dropdown-btn draggable" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-id="<%= tag.tag_id%>">
-                  <span><%= tag.tag_name || 'Untitled Tag' %></span>
-                   <span>&#9662;</span> <!-- Down arrow symbol -->
-              </button>
-              <div class="dropdown-content">
-                <a onclick="addTagOnClick('tag', '<%=tag.tag_id%>', '<%=tag.tag_name%>', '<%=tag.tag_name%>')" class="draggable" href="#subitem1" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-id="<%=tag.tag_id%>" any-tag="True">Any</a>
-                  <% const filteredValues = tagValues.filter(value => value.tag_id === tag.tag_id); %>
-                  <% if (filteredValues && filteredValues.length > 0) { %>
-                      <% filteredValues.forEach(value => { %>
-                        <a onclick="addTagOnClick('subtag', '<%=value.value_id%>', '<%=tag.tag_name%>', '<%= value.tag_value %>')" class="draggable" href="#subitem1" draggable="true" data-tag-name="<%= tag.tag_name %>" data-subtag-id="<%=value.value_id%>"><%= value.tag_value %></a>
-                        <% }); %>
-                  <% } else { %>
-                      <a href="#subitem2">No values</a>
-                  <% } %>
-              </div>
-          <% }); %>
-          </div>
-          <br>
+
           
-          <button onclick="clearRecentTags()">Clear Recent Tags</button>
+
+       <!-- Dropdown for favorite tags -->
+        <button class="dropdown-btn">
+          <span>Favorites</span>
+          <span>&#9662;</span>
+        </button>
+        <div class="dropdown-content" id="favoriteTagsDropdown"></div> <!-- Dropdown for favorite tags -->
+        <br>
+        
+          <!-- <button onclick="clearFavoriteTags()">Clear Favorite Tags</button> -->
 
           <button class="dropdown-btn">
             <span>Recent</span>
@@ -69,24 +64,37 @@
    
              <!-- Dropdown List Section -->
           
-               <% tags.forEach(tag => { %> <!-- this is all the tags  -->
-                 <button class="dropdown-btn draggable" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-id="<%= tag.tag_id%>">
-                   <span><%= tag.tag_name || 'Untitled Tag' %></span>
-                   <span>&#9662;</span> <!-- Down arrow symbol -->
-                 </button>
-                 
-                 <div class="dropdown-content">
-                  <a onclick="addTagOnClick('tag', '<%=tag.tag_id%>', '<%=tag.tag_name%>', '<%=tag.tag_name%>')" class="draggable" href="#subitem1" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-id="<%=tag.tag_id%>" any-tag="True">Any</a>
-                  <% const filteredValues = tagValues.filter(value => value.tag_id === tag.tag_id); %>
-                   <% if (filteredValues && filteredValues.length > 0) { %>
-                     <% filteredValues.forEach(value => { %>
-                      <a onclick="addTagOnClick('subtag', '<%=value.value_id%>', '<%=tag.tag_name%>', '<%= value.tag_value %>')" class="draggable" href="#subitem1" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-value="<%= value.tag_value %>" data-tag-id="<%= tag.tag_id %>" data-subtag-id="<%=value.value_id%>"><%= value.tag_value %></a>
-                      <% }); %>
-                   <% } else { %>
-                     <a href="#subitem2">No values</a>
-                   <% } %>
-                 </div>
-               <% }); %>
+             <% tags.forEach(tag => { %> <!-- This is all the tags -->
+              <button class="dropdown-btn draggable" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-id="<%= tag.tag_id %>">
+                <span><%= tag.tag_name || 'Untitled Tag' %></span>
+                <span>&#9662;</span> <!-- Down arrow symbol -->
+              </button>
+            
+              <div class="dropdown-content">
+                <a onclick="addTagOnClick('tag', '<%=tag.tag_id%>', '<%=tag.tag_name%>', '<%=tag.tag_name%>')" class="draggable" href="#subitem1" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-id="<%=tag.tag_id%>" any-tag="True">Any</a>
+            
+                <% const filteredValues = tagValues.filter(value => value.tag_id === tag.tag_id); %>
+                <% if (filteredValues && filteredValues.length > 0) { %>
+                  <% filteredValues.forEach(value => { %>
+                    <div class="dropdown-item-wrapper">
+                      <a onclick="addTagOnClick('subtag', '<%= value.value_id %>', '<%= tag.tag_name %>', '<%= value.tag_value %>')" class="draggable" href="#subitem1" draggable="true" data-tag-name="<%= tag.tag_name %>" data-tag-value="<%= value.tag_value %>" data-tag-id="<%= tag.tag_id %>" data-subtag-id="<%= value.value_id %>">
+                        <%= value.tag_value %>
+                      </a>
+                      
+                      <!-- Star icon with dynamic class and toggle functionality -->
+                      <i class="bi bi-star favorite-btn" id="star-<%= value.value_id %>"
+                        onclick="toggleFavoriteTag('subtag', '<%= value.value_id %>', '<%= tag.tag_name %>', '<%= value.tag_value %>')"></i>
+                    </div>
+                  <% }); %>
+                <% } else { %> 
+                  <div class="dropdown-item-wrapper">
+                    <a href="#subitem2">No values</a>
+                    <i class="bi bi-star favorite-btn" id="star-<%= tag.tag_id %>"></i> <!-- Default empty star -->
+                  </div>
+                <% } %>
+              </div>
+            <% }); %>
+            
       </div>
    
    <!-- Main Content Area -->


### PR DESCRIPTION
**This PR introduces the "Recent" and "Favorite" tag features to the Tag Explorer page.**  
Users can now store and view their most recently selected tags and favorite tags, enhancing the user experience. The following changes have been made:

### Recent Tags:
- Implemented functionality to store recently selected tags in the local storage.
- Added a limit of 10 recent tags (for test purposes), with older tags removed when the limit is exceeded.

### Favorite Tags:
- Enabled the ability to mark tags as favorites and store them in local storage.
- Introduced a limit of 10 favorite tags (for testing), with older favorites discarded when the limit is reached.

### UI Updates:
- Added dynamic dropdowns for both recent and favorite tags, making it easier to manage and interact with them.

These updates enhance the user interface by providing quick access to the most recently and favorited tags on the Tag Explorer page.

**Note:** The limit of 10 tags for both "Recent" and "Favorite" is set temporarily for testing purposes. This value can be adjusted in the future based on requirements.
